### PR TITLE
Set MAC address via config file.

### DIFF
--- a/50_configure_xeoma.sh
+++ b/50_configure_xeoma.sh
@@ -16,6 +16,11 @@ function ts {
 
 #-----------------------------------------------------------------------------------------------------------------------
 
+if [ -n "$MAC_ADDRESS" ]; then
+  echo "$(ts) Setting container mac address to $MAC_ADDRESS"
+  ip link set eth0 address $MAC_ADDRESS
+fi
+
 # Save some information about the interface that talks to the internet, in case we need it later.
 
 # Have to parse /proc/net/route because there is no "ip" to do this: iface=$(ip route show default | awk '/default/ {print $5}')

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ echo "Acquire::http {No-Cache=True;};" > /etc/apt/apt.conf.d/no-cache && \
 \
 # Install prerequisites
 apt-get update && \
-apt-get install -qy libasound2 wget && \
+apt-get install -qy libasound2 iproute2 wget && \
 \
 # clean up
 apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Be careful about choosing your networking settings before installing your licens
 
 However, if you have any issues, the container will append some information about the MAC address to the file macs.txt each time it starts. If you have trouble getting the license to work, try using the `--mac-address` flag to the run command to force your new container to have the same MAC address as your old one. This will only work if you are using bridged networking.
 
+Alternatively, or if you are running in a Kubernetes and cannot set your mac address, you can set the MAC_ADDRESS variable in the xeoma.conf file.  The container will set its own MAC address at startup.  
+
 Finally, if all else fails, [use the felenasoft website for help](http://felenasoft.com/xeoma/en/support/activation-issues/).
 
 ### Discovering Cameras


### PR DESCRIPTION
I'm running the container in Kubernetes.  Every time the container is stopped and started, it gets a new MAC address, which breaks licensing.  Kubernetes also doesn't allow one to set the mac address because the networking layer implementations don't support it.
This PR allows one to set the MAC_ADDRESS variable in the xeoma.conf.  It's then set in the container before the xeoma server starts.