### PR TITLE
Fix permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,24 +8,24 @@ ENV TERM=xterm-256color
 CMD ["/sbin/my_init"]
 
 RUN true && \
-\
-DEBIAN_FRONTEND=noninteractive && \
-\
-# Speed up APT
-echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup && \
-echo "Acquire::http {No-Cache=True;};" > /etc/apt/apt.conf.d/no-cache && \
-\
-# Install prerequisites
-apt-get update && \
-apt-get install -qy libasound2 wget && \
-\
-# clean up
-apt-get clean && \
-rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-/usr/share/man /usr/share/groff /usr/share/info \
-/usr/share/lintian /usr/share/linda /var/cache/man && \
-(( find /usr/share/doc -depth -type f ! -name copyright|xargs rm || true )) && \
-(( find /usr/share/doc -empty|xargs rmdir || true ))
+  \
+  DEBIAN_FRONTEND=noninteractive && \
+  \
+  # Speed up APT
+  echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup && \
+  echo "Acquire::http {No-Cache=True;};" > /etc/apt/apt.conf.d/no-cache && \
+  \
+  # Install prerequisites
+  apt-get update && \
+  apt-get install -qy libasound2 wget && \
+  \
+  # clean up
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  /usr/share/man /usr/share/groff /usr/share/info \
+  /usr/share/lintian /usr/share/linda /var/cache/man && \
+  (( find /usr/share/doc -depth -type f ! -name copyright|xargs rm || true )) && \
+  (( find /usr/share/doc -empty|xargs rmdir || true ))
 
 VOLUME [ "/config", "/archive" ]
 
@@ -44,8 +44,12 @@ RUN chmod +x /etc/my_init.d/30_parse_config_file.sh /etc/my_init.d/40_install_xe
 COPY update_xeoma.sh /etc/cron.hourly/update_xeoma
 RUN chmod +x /etc/cron.hourly/update_xeoma
 
+# Script to set permissions to not be world-writable
+COPY update-permissions.sh /etc/cron.hourly/update-permissions.sh
+RUN chmod +x /etc/cron.hourly/update-permissions.sh
+
 COPY xeoma.sh /etc/service/xeoma/run
 RUN chmod +x /etc/service/xeoma/run
 
 RUN mkdir /archive-cache && \
-echo 'This is a placeholder to detect when a host volume is mapped to /archive-cache' > /archive-cache/4vagl0js6k
+  echo 'This is a placeholder to detect when a host volume is mapped to /archive-cache' > /archive-cache/4vagl0js6k

--- a/update-permissions.sh
+++ b/update-permissions.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+/bin/sleep 8
+/bin/chmod -R og-rwx /config
+/bin/chmod -R og-w /archive
+/bin/chmod -R og-w /archive-cache
+
+echo "[`date '+%b %d %X'`] Applied permissions restrictions"

--- a/xeoma.sh
+++ b/xeoma.sh
@@ -18,3 +18,6 @@ else
     echo "$(ts) Using archive cache"
     /usr/bin/xeoma -core -service -log -startdelay 5 -archivecache /archive-cache
 fi
+
+sleep 3
+chmod -R og-w /config

--- a/xeoma.sh
+++ b/xeoma.sh
@@ -10,6 +10,9 @@ function ts {
 
 echo "$(ts) Starting the server in 5 seconds. See the log directory in your config directory for server logs."
 
+# Fire off the delayed permissions setting manually
+/etc/cron.hourly/update-permissions.sh &
+
 if [[ -e /archive-cache/4vagl0js6k ]]
 then
     echo "$(ts) Not using archive cache"
@@ -18,6 +21,3 @@ else
     echo "$(ts) Using archive cache"
     /usr/bin/xeoma -core -service -log -startdelay 5 -archivecache /archive-cache
 fi
-
-sleep 3
-chmod -R og-w /config


### PR DESCRIPTION
Xeoma wants to have world writable files, which is a really Bad Thing.

This modification adds a script to set the permissions more appropriately on the folders exposed and to keep applying them each hour via CRON.